### PR TITLE
Settings to exclude any file type

### DIFF
--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -1,0 +1,15 @@
+module.exports =
+	excludeFileTypes:
+		type: "object"
+		properties:
+			enabled:
+				order: 1
+				title: "Enabled"
+				type: "boolean"
+				default: true
+			excluded:
+				order: 2
+				title: "Don't check these file types:"
+				description: "Use comma separated, lowercase values (e.g. `pdf, ico, png`)"
+				type: "array"
+				default: [ "png", "jpeg", "jpg", "gif", "ico" ]

--- a/lib/config-schema.coffee
+++ b/lib/config-schema.coffee
@@ -12,4 +12,4 @@ module.exports =
 				title: "Don't check these file types:"
 				description: "Use comma separated, lowercase values (e.g. `pdf, ico, png`)"
 				type: "array"
-				default: [ "png", "jpeg", "jpg", "gif", "ico" ]
+				default: [ "png", "jpeg", "jpg", "gif", "ico", "bmp", "webp" ]

--- a/lib/open-no-binaries.coffee
+++ b/lib/open-no-binaries.coffee
@@ -1,21 +1,45 @@
-path = require 'path'
-isbinaryfile = require 'isbinaryfile'
-fs = require 'fs-plus'
+path        = require 'path'
+isbinaryfile= require 'isbinaryfile'
+fs          = require 'fs-plus'
+configs     = require './config-schema'
+
+extension = (path) ->
+    path.split('.').pop().toLowerCase()
+
+fileBasename = (path) ->
+    path.split('\\').pop()# path.substr(path.lastIndexOf('\\')).replace('\\','')
+
+
+############################# CONFIGS #############################
+arr_excluded = atom.config.get('open-no-binaries.excludeFileTypes.excluded') ? []
+
+atom.config.onDidChange 'open-no-binaries.excludeFileTypes.excluded', ({newValue, oldValue}) ->
+    arr_excluded = newValue
+
+atom.config.onDidChange 'open-no-binaries.excludeFileTypes.enabled', ({newValue, oldValue}) ->
+    if newValue
+        arr_excluded = atom.config.get('open-no-binaries.excludeFileTypes.excluded') ? []
+    else
+        arr_excluded = []
+###################################################################
+
 
 module.exports = OpenNoBinaries =
-  opener: null
+    config: configs
+    opener: null
 
-  activate: (state) ->
-    @opener = atom.workspace.addOpener (uri) ->
-      # ignore protocols
-      if /^[a-z-]+:\/\//.test(uri)
-        return
-      # check only files
-      if not fs.isFileSync(uri)
-        return false
-      if isbinaryfile.sync(uri)
-        atom.notifications.addInfo('Binary detected \'' + uri + '\'.')
-        return false
+    activate: (state) ->
+        @opener = atom.workspace.addOpener (uri) ->
+            # ignore protocols
+            if /^[a-z-]+:\/\//.test(uri)
+                return
+            # check only files
+            if not fs.isFileSync(uri)
+                return false
 
-  deactivate: ->
-    @opener.dispose()
+            if extension(uri) not in arr_excluded and isbinaryfile.sync(uri)
+                atom.notifications.addInfo("Binary Detected: '#{fileBasename(uri)}'")
+                return false
+
+        deactivate: ->
+            @opener.dispose()


### PR DESCRIPTION
:atom: **Atom** has packages to view some binaries files _([atom-image-view](https://github.com/atom/image-view) and [pdf-view](https://github.com/izuzak/atom-pdf-view))_.
So, I'd like to have an option to ignore these file types 😊

Something like this:
![settings preview](https://cloud.githubusercontent.com/assets/13461315/24890232/9f0d6d52-1e3c-11e7-8263-40e916c5d230.png)



